### PR TITLE
using element properties when they exist and are not "special" attributes

### DIFF
--- a/behaviors.js
+++ b/behaviors.js
@@ -419,11 +419,13 @@ var attr = {
 		return specialAttributes[attributeName] && specialAttributes[attributeName].addEventListener;
 	},
 
-	setAttrOrProp: function(el, attrName, val){
-		attrName = attrName.toLowerCase();
+	setAttrOrProp: function(el, caseSensitiveAttrName, val){
+		var attrName = caseSensitiveAttrName.toLowerCase();
 		var special = specialAttributes[attrName];
 		if(special && special.isBoolean && !val) {
 			this.remove(el, attrName);
+		} else if (!special && caseSensitiveAttrName in el) {
+			el[caseSensitiveAttrName] = val;
 		} else {
 			this.set(el, attrName, val);
 		}
@@ -454,15 +456,20 @@ var attr = {
 		}
 	},
 	// ## attr.get
-	// Gets the value of an attribute. First checks if the property is an `specialAttributes` and if so calls the special getter. Otherwise uses `getAttribute` to retrieve the value.
-	get: function (el, attrName) {
-		attrName = attrName.toLowerCase();
+	// Gets the value of an attribute or property.
+	// First checks if the property is an `specialAttributes` and if so calls the special getter.
+	// Then checks if the attribute or property is a property on the element.
+	// Otherwise uses `getAttribute` to retrieve the value.
+	get: function (el, caseSensitiveAttrName) {
+		var attrName = caseSensitiveAttrName.toLowerCase();
 		var special = specialAttributes[attrName];
 		var getter = special && special.get;
 		var test = getSpecialTest(special);
 
 		if(typeof getter === "function" && test.call(el)) {
 			return getter.call(el);
+		} else if (caseSensitiveAttrName in el) {
+			return el[caseSensitiveAttrName];
 		} else {
 			return el.getAttribute(attrName);
 		}

--- a/can-attribute-observable-test.js
+++ b/can-attribute-observable-test.js
@@ -64,9 +64,7 @@ testHelpers.makeTests("AttributeObservable", function(
 		domEvents.dispatch(input, "change");
 	});
 
-
 	testIfRealDocument("able to read normal attributes", function(assert) {
-
 		var div = document.createElement("div");
 		div.setAttribute("foo","bar");
 
@@ -76,5 +74,22 @@ testHelpers.makeTests("AttributeObservable", function(
 		var obs = new AttributeObservable(div, "foo", {});
 
 		assert.equal(canReflect.getValue(obs), "bar", "correct default value");
+	});
+
+	testIfRealDocument("able to read and write properties when they exist on the element and are not in 'special' list", function(assert) {
+		var video = document.createElement("video");
+		video.currentTime = 5.0;
+
+		var ta = this.fixture;
+		ta.appendChild(video);
+
+		var obs = new AttributeObservable(video, "currentTime", {});
+
+		assert.equal(canReflect.getValue(obs), 5.0, "correct default value");
+
+		canReflect.setValue(obs, 10.0);
+
+		assert.equal(canReflect.getValue(obs), 10.0, "correct updated value");
+		assert.equal(video.currentTime, 10.0, "correct updated property");
 	});
 });


### PR DESCRIPTION
closes #1.