### PR TITLE
not using cached element in attribute getter/setter

### DIFF
--- a/behaviors-test.js
+++ b/behaviors-test.js
@@ -44,11 +44,11 @@ testHelpers.makeTests("AttributeObservable - behaviors", function(
 		}, {
 			el: video,
 			attrOrPropName: "currentTime",
-			expectedRule: behaviors.property(video, "currentTime")
+			expectedRule: behaviors.property("currentTime")
 		}, {
 			el: circle,
 			attrOrPropName: "r",
-			expectedRule: behaviors.attribute(circle, "r")
+			expectedRule: behaviors.attribute("r")
 		}].forEach(function(testCase) {
 			assert.equal(
 				behaviors.getRule(testCase.el, testCase.attrOrPropName),

--- a/behaviors.js
+++ b/behaviors.js
@@ -487,30 +487,30 @@ var attr = {
 
 		// if the element doesn't have a property of this name, it must be an attribute
 		if (!(attrOrPropName in el)) {
-			return this.attribute(el, attrOrPropName);
+			return this.attribute(attrOrPropName);
 		}
 
 		// if there is a property, check if it is writable
 		var newRule = isPropWritable(el, attrOrPropName) ?
-			this.property(el, attrOrPropName) :
-			this.attribute(el, attrOrPropName);
+			this.property(attrOrPropName) :
+			this.attribute(attrOrPropName);
 
 		// cache the new rule and return it
 		return cacheRule(el, attrOrPropName, newRule);
 	},
 
-	attribute: function(el, attrName) {
+	attribute: function(attrName) {
 		return {
 			get: function() {
-				return el.getAttribute(attrName);
+				return this.getAttribute(attrName);
 			},
 			set: function(val) {
-				domMutateNode.setAttribute.call(el, attrName, val);
+				domMutateNode.setAttribute.call(this, attrName, val);
 			}
 		};
 	},
 
-	property: function(el, propName) {
+	property: function(propName) {
 		return {
 			get: function() {
 				return this[propName];

--- a/can-attribute-observable-test.js
+++ b/can-attribute-observable-test.js
@@ -126,4 +126,21 @@ testHelpers.makeTests("AttributeObservable", function(
 		assert.equal(canReflect.getValue(obsOne), "http://img.one/", "obsOne correct updated value");
 		assert.equal(canReflect.getValue(obsTwo), "http://img.two/", "obsTwo correct updated value");
 	});
+
+	testIfRealDocument("can correctly set the same attribute on two different elements of the same type", function(assert) {
+		var circleOne = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+		var obsOne = new AttributeObservable(circleOne, "r", {});
+
+		var circleTwo = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+		var obsTwo = new AttributeObservable(circleTwo, "r", {});
+
+		assert.equal(canReflect.getValue(obsOne), null, "obsOne correct default value");
+		assert.equal(canReflect.getValue(obsTwo), null, "obsTwo correct default value");
+
+		canReflect.setValue(obsOne, 10);
+		canReflect.setValue(obsTwo, 20);
+
+		assert.equal(canReflect.getValue(obsOne), 10, "obsOne correct updated value");
+		assert.equal(canReflect.getValue(obsTwo), 20, "obsTwo correct updated value");
+	});
 });


### PR DESCRIPTION
closes https://github.com/canjs/can-attribute-observable/issues/6.