### PR TITLE
fixes #16, makes focused work

### DIFF
--- a/behaviors-test.js
+++ b/behaviors-test.js
@@ -1,5 +1,9 @@
 var testHelpers = require("../test/helpers");
 var behaviors = require("./behaviors");
+var canReflect = require("can-reflect");
+var AttributeObservable = require("can-attribute-observable");
+var domEvents = require("can-dom-events");
+var queues = require("can-queues");
 
 var mock = function(obj, fnName) {
 	var origFn = obj[fnName];
@@ -61,5 +65,73 @@ testHelpers.makeTests("AttributeObservable - behaviors", function(
 
 		// clear out cached rules using mock behaviors methods
 		behaviors.rules.clear();
+	});
+
+	testIfRealDocument("select changes value", function(){
+		var html = "<select>" +
+			"<option value='red'>Red</option>" +
+			"<option value='green'>Green</option>" +
+		"</select>";
+
+		var div = document.createElement("div");
+		div.innerHTML = html;
+		var select = div.firstChild;
+
+		var obs = new AttributeObservable(select, "value", {});
+
+		var dispatchedValues = [];
+		canReflect.onValue(obs,function(newVal){
+			dispatchedValues.push(newVal);
+		});
+
+		var ta = this.fixture;
+		ta.appendChild(select);
+
+		// INIT TO GREEN
+		canReflect.setValue(obs,"green");
+
+		// Now have the user change it to "red"
+		canReflect.each(ta.getElementsByTagName('option'), function(opt) {
+			if (opt.value === 'red') {
+				opt.selected = 'selected';
+			}
+		});
+		domEvents.dispatch(select, "change");
+
+		// It should have dispatched green and red
+		// red is most important.  There is probably a bug
+		// in that it is not dispatching red.
+		QUnit.deepEqual(dispatchedValues,["red"], "dispatched the right events");
+	});
+
+	testIfRealDocument("focused set at end of queues (#16)", 5, function(assert) {
+		var input = document.createElement("input");
+		var otherInput = document.createElement("input");
+
+		var ta = this.fixture;
+		ta.appendChild(input);
+		ta.appendChild(otherInput);
+		otherInput.focus();
+
+		var obs = new AttributeObservable(input, "focused", {});
+		assert.notEqual(input, document.activeElement, "not focused");
+
+		assert.equal(obs.get(), false, "observable is false");
+
+		var eventValues = [];
+		canReflect.onValue(obs, function(newVal){
+			eventValues.push(newVal);
+		},"domUI");
+
+		queues.batch.start();
+		queues.domUIQueue.enqueue(function(){
+			assert.notEqual(input, document.activeElement, "not focused in the DOM UI Queue");
+		});
+		canReflect.setValue(obs,true);
+		queues.batch.stop();
+
+		assert.equal(input, document.activeElement, "focused");
+
+		QUnit.deepEqual(eventValues,[true], "became focused once");
 	});
 });

--- a/can-attribute-observable-test.js
+++ b/can-attribute-observable-test.js
@@ -169,4 +169,5 @@ testHelpers.makeTests("AttributeObservable", function(
 				"disabled = " + (typeof t.input === "string" ? '"' + t.input + '"' : t.input) + " sets disabled to " + t.output);
 		});
 	});
+
 });

--- a/can-attribute-observable.js
+++ b/can-attribute-observable.js
@@ -82,15 +82,18 @@ Object.assign(AttributeObservable.prototype, {
 	},
 
 	set: function set(newVal) {
-		attr.setAttrOrProp(this.el, this.prop, newVal);
-
+		var setterDispatchedEvents = attr.setAttrOrProp(this.el, this.prop, newVal);
 		// update the observation internal value
-		this.value = newVal;
+		if(!setterDispatchedEvents) {
+			this.value = newVal;
+		}
+
 
 		return newVal;
 	},
 
 	handler: function handler(newVal, event) {
+		console.log("handler called", this.value, newVal);
 		var old = this.value;
 		var queuesArgs = [];
 		this.value = attr.get(this.el, this.prop);
@@ -103,7 +106,7 @@ Object.assign(AttributeObservable.prototype, {
 				}
 			}
 			//!steal-remove-end
-			
+
 
 			queuesArgs = [
 				this.handlers.getNode([]),


### PR DESCRIPTION
This fixes #16 by calling focused in the mutation queue.  However, this caused ordering problems that were fixed by only updating the internal state if the setter would not call dispatch itself.  

There's a decent chance this might break in other browsers.  Though I am still going to release it so CanJS's integration tests will run.