### PR TITLE
Function attributes to have the correct `this`

### DIFF
--- a/behaviors-test.js
+++ b/behaviors-test.js
@@ -134,4 +134,18 @@ testHelpers.makeTests("AttributeObservable - behaviors", function(
 
 		QUnit.deepEqual(eventValues,[true], "became focused once");
 	});
+
+	testIfRealDocument("bindings for functions are not bound to the correct this (#493)", function(assert) {
+		var div = document.createElement("div");
+		div.myFunc = function () {
+			assert.equal(this, div);
+		};
+
+		var ta = this.fixture;
+		ta.appendChild(div);
+
+		var obs = new AttributeObservable(div, "myFunc");
+		var method = obs.get();
+		method();
+	});
 });

--- a/behaviors.js
+++ b/behaviors.js
@@ -148,7 +148,7 @@ var formElements = {"INPUT": true, "TEXTAREA": true, "SELECT": true},
 	// check if a property is writable on an element by finding its property descriptor
 	// on the element or its prototype chain
 	isPropWritable = function(el, prop) {
-		   var desc = Object.getOwnPropertyDescriptor(el.constructor.prototype, prop);
+		   var desc = Object.getOwnPropertyDescriptor(el, prop);
 
 		   if (desc) {
 				   return desc.writable || desc.set;

--- a/can-attribute-observable.js
+++ b/can-attribute-observable.js
@@ -78,7 +78,11 @@ Object.assign(AttributeObservable.prototype, {
 				Observation.temporarilyBind(this);
 			}
 		}
-		return attr.get(this.el, this.prop);
+		var value = attr.get(this.el, this.prop);
+		if (typeof value === 'function') {
+			value = value.bind(this.el);
+		}
+		return value;
 	},
 
 	set: function set(newVal) {


### PR DESCRIPTION
When using functions for attributes have the correct binding for `this`

https://github.com/canjs/can-stache-bindings/issues/493