### PR TITLE
handle undefined value in textarea

### DIFF
--- a/behaviors-test.js
+++ b/behaviors-test.js
@@ -148,4 +148,20 @@ testHelpers.makeTests("AttributeObservable - behaviors", function(
 		var method = obs.get();
 		method();
 	});
+
+	testIfRealDocument("setting .value on a textarea to undefined or null makes value empty string (28)", function(assert){
+		var textarea = document.createElement("textarea");
+
+		var ta = this.fixture;
+		ta.appendChild(textarea);
+
+		var obs = new AttributeObservable(textarea, "value");
+		obs.set('something');
+		assert.equal(obs.get(), "something", "correct string value");
+
+		obs.set(null);
+		assert.equal(obs.get(), "", "null handled correctly");
+		obs.set(undefined);
+		assert.equal(obs.get(), "", "undefined handled correctly");
+	});
 });

--- a/behaviors.js
+++ b/behaviors.js
@@ -350,7 +350,7 @@ var specialAttributes = {
 		},
 		set: function(value){
 			var nodeName = this.nodeName.toLowerCase();
-			if(nodeName === "input") {
+			if(nodeName === "input" || nodeName === "textarea") {
 				// Do some input types support non string values?
 				value = toString(value);
 			}


### PR DESCRIPTION
This fixes an issue where `<textarea>` elements were rendering `undefined` in the DOM, when it should render nothing. The same fix was previously applied for `can-util` here: https://github.com/canjs/can-util/pull/416

Closes #28 