### PR TITLE
svg-use-fix: use setAttributeNS()

### DIFF
--- a/behaviors-test.js
+++ b/behaviors-test.js
@@ -165,4 +165,31 @@ testHelpers.makeTests("AttributeObservable - behaviors", function(
 		obs.set(undefined);
 		assert.equal(obs.get(), "", "undefined handled correctly");
 	});
+
+	testIfRealDocument("should use setAttributeNS instead of setAttribute for namespaced-attributes", function(assert) {
+		var svgNamespaceURI =  "http://www.w3.org/2000/svg";
+		var xlinkHrefAttrNamespaceURI =  "http://www.w3.org/1999/xlink";
+		var xlinkHrefAttr = "xlink:href";
+		var origValue = "icons.svg#logo";
+		var newValue = "icons.svg#pointDown";
+
+		var svg = document.createElementNS(svgNamespaceURI, "svg");
+		var svgUse = document.createElementNS(svgNamespaceURI, "use");
+		svgUse.setAttributeNS(xlinkHrefAttrNamespaceURI, xlinkHrefAttr, origValue);
+		svg.appendChild(svgUse);
+
+		var ta = this.fixture;
+		ta.appendChild(svg);
+
+		var obs = new AttributeObservable(svgUse, xlinkHrefAttr);
+
+		// test get
+		var origValueNS = obs.get(xlinkHrefAttr);
+		assert.equal(origValueNS, origValue, "get should match origValue");
+
+		// test set
+		obs.set(newValue);
+		assert.equal(svgUse.getAttributeNS(xlinkHrefAttrNamespaceURI, "href"), newValue, "getAttributeNS() should match newValue");
+		assert.equal(svgUse.getAttribute(xlinkHrefAttr), newValue, "getAttribute() should match newValue");
+	});
 });

--- a/behaviors.js
+++ b/behaviors.js
@@ -10,6 +10,14 @@ var getMutationObserver = require("can-globals/mutation-observer/mutation-observ
 var diff = require("can-diff/list/list");
 var queues = require("can-queues");
 
+var xmlnsAttrNamespaceURI = "http://www.w3.org/2000/xmlns/";
+var xlinkHrefAttrNamespaceURI =  "http://www.w3.org/1999/xlink";
+var attrsNamespacesURI = {
+	'xmlns': xmlnsAttrNamespaceURI,
+	'xlink:href': xlinkHrefAttrNamespaceURI
+};
+
+
 var formElements = {"INPUT": true, "TEXTAREA": true, "SELECT": true, "BUTTON": true},
 	// Used to convert values to strings.
 	toString = function(value){
@@ -493,10 +501,14 @@ var attr = {
 	attribute: function(attrName) {
 		return {
 			get: function() {
-				return this.getAttribute(attrName);
+				return (attrsNamespacesURI[attrName]) ? this.getAttributeNS(attrsNamespacesURI[attrName], attrName) : this.getAttribute(attrName);
 			},
 			set: function(val) {
-				domMutateNode.setAttribute.call(this, attrName, val);
+				if (attrsNamespacesURI[attrName]) {
+					domMutateNode.setAttributeNS.call(this, attrsNamespacesURI[attrName], attrName, val);
+				} else {
+					domMutateNode.setAttribute.call(this, attrName, val);
+				}
 			}
 		};
 	},

--- a/behaviors.js
+++ b/behaviors.js
@@ -501,7 +501,7 @@ var attr = {
 	attribute: function(attrName) {
 		return {
 			get: function() {
-				return (attrsNamespacesURI[attrName]) ? this.getAttributeNS(attrsNamespacesURI[attrName], attrName) : this.getAttribute(attrName);
+				return this.getAttribute(attrName);
 			},
 			set: function(val) {
 				if (attrsNamespacesURI[attrName]) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "can-diff": "^1.0.1",
     "can-dom-data": "^1.0.1",
     "can-dom-events": "^1.1.2",
-    "can-dom-mutate": "^2.0.5",
+    "can-dom-mutate": "^1.3.11",
     "can-event-dom-radiochange": "^2.1.0",
     "can-globals": "^1.0.1",
     "can-observation": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "can-diff": "^1.0.1",
     "can-dom-data": "^1.0.1",
     "can-dom-events": "^1.1.2",
-    "can-dom-mutate": "^1.0.3",
+    "can-dom-mutate": "^2.0.5",
     "can-event-dom-radiochange": "^2.1.0",
     "can-globals": "^1.0.1",
     "can-observation": "^4.0.1",


### PR DESCRIPTION
SVG namespace fix when svg-attribute contains stache-expression

dependent on https://github.com/canjs/can-dom-mutate/pull/68 for `setAttributeNS()`-support